### PR TITLE
Improve text formatting and responsiveness in canvas rendering

### DIFF
--- a/api/canvas.ts
+++ b/api/canvas.ts
@@ -25,14 +25,28 @@ export function getImage(record: Record): Uint8Array {
   ctx.fillStyle = 'white';
   ctx.textAlign = 'center';
 
-  ctx.font = '48px Montserrat';
+  function fitText(txt: string, maxW: number, maxF: number): string {
+    let f = maxF;
+    ctx.font = `${f}px Montserrat`;
+
+    while (ctx.measureText(txt).width > maxW) {
+      f -= 4;
+      ctx.font = `${f}px Montserrat`;
+    }
+    return ctx.font;
+  }
+
+  ctx.font = fitText(`${record.event} ${record.type} ${record.tag}`, 900, 48);
   ctx.fillText(`${record.event} ${record.type} ${record.tag}`, 500, 100);
-  ctx.fillText(`by ${record.person}`, 500, 175);
+
+  const personText = `by ${record.person}`;
+  ctx.font = fitText(personText, 900, 48);
+  ctx.fillText(personText, 500, 175);
 
   ctx.font = '256px cubing-icons';
   ctx.fillText(record.icon, 500, 610);
 
-  ctx.font = '224px Montserrat';
+  ctx.font = fitText(record.time.toString(), 900, 224);
   ctx.fillText(record.time.toString(), 500, 925);
 
   return canvas.toBuffer('image/png');

--- a/api/format.ts
+++ b/api/format.ts
@@ -1,0 +1,56 @@
+// from https://github.com/thewca/wca-live/blob/main/client/src/lib/attempt-result.js
+// --------------------------------------------------------------------------------------------
+
+export function formatAttemptResult(attemptResult: number, eventId: string): string {
+  if (eventId === '333mbf') return formatMbldAttemptResult(attemptResult);
+  if (eventId === '333fm') return formatFmAttemptResult(attemptResult);
+  return centisecondsToClockFormat(attemptResult);
+}
+
+export function decodeMbldAttemptResult(value: number) {
+  if (value <= 0) return { solved: 0, attempted: 0, centiseconds: value };
+  const missed = value % 100;
+  const seconds = Math.floor(value / 100) % 1e5;
+  const points = 99 - (Math.floor(value / 1e7) % 100);
+  const solved = points + missed;
+  const attempted = solved + missed;
+  const centiseconds = seconds === 99999 ? null : seconds * 100;
+  return { solved, attempted, centiseconds };
+}
+
+function formatMbldAttemptResult(attemptResult: number) {
+  const { solved, attempted, centiseconds } =
+    decodeMbldAttemptResult(attemptResult);
+  const clockFormat = centisecondsToClockFormat(centiseconds);
+  const shortClockFormat = clockFormat.replace(/\.00$/, '');
+  return `${solved}/${attempted} ${
+    centiseconds < 6000 ? `0:${shortClockFormat}` : shortClockFormat
+  }`;
+}
+
+function formatFmAttemptResult(attemptResult: number) {
+  /* Note: FM singles are stored as the number of moves (e.g. 25),
+     while averages are stored with 2 decimal places (e.g. 2533 for an average of 25.33 moves). */
+  const isAverage = attemptResult >= 1000;
+  return isAverage
+    ? (attemptResult / 100).toFixed(2)
+    : attemptResult.toString();
+}
+
+export function centisecondsToClockFormat(centiseconds: number) {
+  if (!Number.isFinite(centiseconds)) {
+    throw new Error(
+      `Invalid centiseconds, expected positive number, got ${centiseconds}.`
+    );
+  }
+  return new Date(centiseconds * 10)
+    .toISOString()
+    .substr(11, 11)
+    .replace(/^[0:]*(?!\.)/g, '');
+}
+
+// --------------------------------------------------------------------------------------------
+
+export function capitalizeFirstLetter(val: string) {
+    return String(val).charAt(0).toUpperCase() + String(val).slice(1);
+}

--- a/api/main.ts
+++ b/api/main.ts
@@ -62,8 +62,8 @@ export default async (_, response) => {
 export type Record = {
   id: string;
   tag: 'WR' | 'CR';
-  type: 'single' | 'average';
-  time: number;
+  type: 'Single' | 'Average';
+  time: string;
   person: string;
   country: string;
   event: string;

--- a/api/wca.ts
+++ b/api/wca.ts
@@ -1,7 +1,7 @@
 import wretch from 'wretch';
 import { Record } from './main.js';
 import { getIcon } from './cubing-icons.js';
-import { capitalizeFirstLetter, formatAttemptResult } from './format.js';
+import { capitalizeFirstLetter, formatAttemptResult } from './format';
 
 export async function getRecords(): Promise<Record[]> {
   const response = await wretch('https://live.worldcubeassociation.org/api')
@@ -51,7 +51,7 @@ export async function getRecords(): Promise<Record[]> {
     );
 
   return response.data.recentRecords
-    .filter((r) => r.result.round.competitionEvent.event.id === '333mbf')
+    .filter((r) => r.tag !== 'NR')
     .map((r) => ({
       id: r.id,
       tag: r.tag as 'WR' | 'CR',
@@ -64,11 +64,3 @@ export async function getRecords(): Promise<Record[]> {
       icon: getIcon(r.result.round.competitionEvent.event.id),
     }));
 }
-
-async function test() {
-  const lol = await getRecords();
-  console.log(lol);
-}
-
-test();
-

--- a/api/wca.ts
+++ b/api/wca.ts
@@ -1,6 +1,7 @@
 import wretch from 'wretch';
 import { Record } from './main.js';
 import { getIcon } from './cubing-icons.js';
+import { capitalizeFirstLetter, formatAttemptResult } from './format.js';
 
 export async function getRecords(): Promise<Record[]> {
   const response = await wretch('https://live.worldcubeassociation.org/api')
@@ -50,12 +51,12 @@ export async function getRecords(): Promise<Record[]> {
     );
 
   return response.data.recentRecords
-    .filter((r) => r.tag !== 'NR')
+    .filter((r) => r.result.round.competitionEvent.event.id === '333mbf')
     .map((r) => ({
       id: r.id,
       tag: r.tag as 'WR' | 'CR',
-      type: r.type as 'single' | 'average',
-      time: r.attemptResult / 100,
+      type: capitalizeFirstLetter(r.type) as 'Single' | 'Average',
+      time: formatAttemptResult(r.attemptResult, r.result.round.competitionEvent.event.id),
       // get rid of the chinese part, because the Montserrat font doesn't support it, e.g. Ng Jia Quan (黄佳铨)
       person: r.result.person.name.replace(/\(.*\)/g, '').trim(),
       country: r.result.person.country.name,
@@ -63,3 +64,11 @@ export async function getRecords(): Promise<Record[]> {
       icon: getIcon(r.result.round.competitionEvent.event.id),
     }));
 }
+
+async function test() {
+  const lol = await getRecords();
+  console.log(lol);
+}
+
+test();
+


### PR DESCRIPTION
Hello, awesome bot!
I’ve contributed some minor improvements to polish things up. 😊
- Result formatting (e.g. 67.48 -> 1:07.48, 333mbf decoding, etc.)
- r.type capitalization
- Responsive text to avoid getting clipped

### Clipping Examples:

**Before & After (Name):**
<img src="https://github.com/user-attachments/assets/06166373-643d-43f9-ad90-11cd244b7d13" alt="record_3349936-single-before" width="300" /><img src="https://github.com/user-attachments/assets/d185bf42-9c60-4ea0-bf52-688a1413d02e" alt="record_3349936-single-after" width="300" />

**Before & After (Result):**
<img src="https://github.com/user-attachments/assets/cc5ce0e1-a86b-43fe-8d68-c6af6ae7fce7" alt="record_3350061-single-before" width="300" /><img src="https://github.com/user-attachments/assets/6941bb59-bbdd-46d3-a2a6-9be9d1014615" alt="record_3350061-single-after" width="300" />
